### PR TITLE
Update route type filtering

### DIFF
--- a/src/data/transport-data.tsx
+++ b/src/data/transport-data.tsx
@@ -105,6 +105,7 @@ export class TJDataSource {
 
     getRoutes = (query: string, routeTypes: Set<string>): Array<BusRoute> => {
         const routes = Object.values(this.routes);
+        if (routeTypes.size === 0) return routes;
         return routes.filter((route) => {
             if (!routeTypes.has(route.type)) {
                 return false;
@@ -187,7 +188,7 @@ export const TransportDataProvider: ParentComponent = (props) => {
     const [filter, setFilter] = createSignal<Filter>({
         query: "",
         selectedRouteIds: new Set(),
-        selectedRouteTypes: new Set(Object.values(RouteType)),
+        selectedRouteTypes: new Set(),
     });
 
     onMount(async () => {

--- a/src/ui/home/sidebar/sidebar.module.scss
+++ b/src/ui/home/sidebar/sidebar.module.scss
@@ -55,15 +55,14 @@
             display: none;
 
             &:checked + p {
-                background: white;
-                opacity: 100;
+                background: #72BF78;
+                color: white;
             }
         }
 
         p {
             margin: 0;
             background: #eaeaea;
-            opacity: 40%;
             width: 100%;
             height: 100%;
             border-radius: 4px;

--- a/src/ui/home/sidebar/sidebar.module.scss
+++ b/src/ui/home/sidebar/sidebar.module.scss
@@ -48,6 +48,7 @@
 
     label {
         display: inline-block;
+        min-height: 48px;
 
         input {
             margin: 0;


### PR DESCRIPTION
Previous: Every type is selected, then when clicking a route type, that route type got filtered out. i.e. clicking BRT removes all BRT routes in the route list

Now: Every type is selected, then when clicking a route type, only that selected type is shown. i.e. clicking BRT now removes every route that's not BRT